### PR TITLE
fix: insert batch items within a transaction

### DIFF
--- a/app/models/description.rb
+++ b/app/models/description.rb
@@ -3,4 +3,16 @@ class Description < ApplicationRecord
   validates :value, presence: true, uniqueness: true
 
   scope :unassigned, -> { where(bucket_id: nil) }
+  scope :create_batch, ->(descs) {
+          existing_descs = all.pluck :value
+          new_descs = descs.uniq - existing_descs
+
+          # Wrap in transaction for more speed. Plus, it makes sense for the
+          # all or none to succeed.
+          output = nil
+          Description.transaction do
+            output = create(new_descs.map { |d| { value: d } })
+          end
+          return output
+        }
 end

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -64,8 +64,14 @@ class LineItem < ApplicationRecord
 
     # In the case an unknown column is entered
     headers_to_delete << nil
+
     # TODO: can discard columns at read time?
     headers_to_delete.each { |s| csv.delete(s) }
-    return LineItem.create!(csv.map { |row| row.to_hash })
+
+    line_items = nil
+    LineItem.transaction do
+      line_items = LineItem.create!(csv.map { |row| row.to_hash })
+    end
+    return line_items
   end
 end

--- a/spec/models/description_spec.rb
+++ b/spec/models/description_spec.rb
@@ -14,5 +14,25 @@ RSpec.describe Description, type: :model do
         expect(Description.unassigned.count).to eq(1)
       end
     end
+
+    context "create_batch" do
+      it "creates descriptions" do
+        d = ["foo", "bar"]
+        res = Description.create_batch d
+        expect(res.length).to eq(d.length)
+        expect(res.map { |d| d.value }).to eq(d)
+      end
+
+      it "creates non-existant descriptions" do
+        d = ["foo", "bar"]
+        Description.create_batch d
+
+        d2 = ["baz"]
+        res = Description.create_batch d + d2
+        expect(res.map { |d| d.value }).to eq(d2)
+
+        expect(Description.count).to eq(d.length + d2.length)
+      end
+    end
   end
 end


### PR DESCRIPTION
Added transaction wrappers for bulk inserts
- Improved data integrity!
- Faster!

Upload and redirect ~2 sec for larger file. Me thinks the index page needs better queries for large tables. Follow up for that.

Closes #45 